### PR TITLE
README: builder recommendation, licence change, and API keys chapter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,146 @@
-MIT License
+PolyForm Noncommercial License 1.0.0
 
-Copyright (c) 2025 Richard
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright (c) 2025 Richard, Webwings
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Required Notice: Copyright (c) 2025 Richard, Webwings (https://webwings.nl)
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright in it
+for any permitted purpose. However, you may only distribute
+the software according to Distribution License and make
+changes or new works based on the software according to
+Changes and New Works License.
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software. Your license
+to distribute covers distributing the software with
+changes and new works permitted by Changes and New Works
+License.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice` that the licensor provided
+with the software. For example:
+
+> Required Notice: Copyright (c) 2025 Richard, Webwings (https://webwings.nl)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study,
+private entertainment, hobby projects, amateur pursuits, or
+religious observance, without any anticipated commercial
+application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else. These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice. Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization. **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.
+
+## General
+
+If any consumer protection law gives you rights you can't waive
+by contract, in conflict with these terms, your relevant
+license(s) for the software is void. If some part of these
+terms is unenforceable, the rest stays in effect. This is
+the entire agreement between the licensor and you concerning
+the licensed software. The licensor is not obligated to
+provide any support for the software. Any notice or
+communication related to these terms should be in writing and
+sent by any means that provides a record of receipt.

--- a/README.md
+++ b/README.md
@@ -282,12 +282,13 @@ https://yourdomain.com/maprouter.php?route=[{"point":"Amsterdam"},{"point":"Utre
 | 2026-07-02 | `maprouter.php`: `?table` panel now supports live editing — reorder route points, move a point to a standalone marker and back, with the URL kept in sync and a "Copy shareable URL" button |
 | 2026-07-02 | `mapbuilder.php`: added reorder (▲/▼) and move (📍 / "move into route") controls so stops and location markers can be rearranged before generating the URL |
 | 2026-07-02 | README: clarified that `maprouter-builder.py` still works correctly, but `mapbuilder.php` is recommended for ease of use |
+| 2026-07-02 | Changed licence from MIT to PolyForm Noncommercial 1.0.0 — free for noncommercial use, commercial use requires separate permission |
 
 ---
 
 ## Licence
 
-This project is licensed under the MIT Licence.
+This project is licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0). Free to use, modify, and share for any noncommercial purpose; commercial use requires separate permission from the licensor.
 
 Copyright © Richard, Webwings 2025
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,17 @@ const config = {
     openRouteServiceApiKey: "YOUR_OPENROUTESERVICE_API_KEY"
 };
 ```
+See [API keys](#api-keys) below for where to obtain each key and what the free tiers offer.
 
 ### 4. Configure staticmap.php (optional)
 
-To enable static PNG map images via , create a  file in the same directory:
+To enable static PNG map images via `staticmap.php`, create a `config.php` file in the same directory:
+```php
+<?php
+$mapboxToken = "YOUR_MAPBOX_TOKEN";
+```
 
-
-
-Obtain a free Mapbox token at [mapbox.com](https://mapbox.com). The static map endpoint accepts the same , , and  parameters as  and returns a PNG image.
-
-
+Obtain a free Mapbox token at [mapbox.com](https://mapbox.com) — see [API keys](#api-keys) below. The static map endpoint accepts the same `route`, `location`, and `color` parameters as `maprouter.php` and returns a PNG image.
 
 ### 5. Open the application
 
@@ -117,6 +118,25 @@ https://yourdomain.com/maprouter.php?route=[...]&location=[...]&layer=[...]&sect
 python3 maprouter-builder.py
 ```
 Set your domain in the `BASE_URL` constant at the top of the script.
+
+---
+
+## API keys
+
+`Nominatim` (geocoding) and the default `OpenStreetMap` tile layer need no key at all — everything else requires a free account. Only sign up for the ones you actually plan to use: skip Tracestrack/Thunderforest entirely if you're happy with the default OSM tiles, and skip Mapbox if you don't need `staticmap.php`.
+
+| Key | Used for | Where to get it | Free tier |
+|---|---|---|---|
+| `openRouteServiceApiKey` | Route calculation (`maprouter.php`) | [openrouteservice.org/dev/#/signup](https://openrouteservice.org/dev/#/signup) — create an account, then generate a key from your dashboard | 2,000 requests/day, 40 requests/minute |
+| `tracestrackApiKey` | Topographic tile layer (`&layer=topo`) | [tracestrack.com](https://tracestrack.com/) — sign up, then find your key on the account/API page | Free tier available (check current limits on their pricing page) |
+| `thunderforestApiKey` | 10 additional tile layers (cycle, transport, outdoors, etc.) | [thunderforest.com](https://www.thunderforest.com/) — sign up, then copy the key from your dashboard | 150,000 tiles/month |
+| Mapbox token (`$mapboxToken` in `config.php`) | Static PNG map images (`staticmap.php` only) | [account.mapbox.com/access-tokens](https://account.mapbox.com/access-tokens/) — sign up, then use the default public token or create a new one | 50,000 requests/month |
+
+**Where each key goes:**
+- `openRouteServiceApiKey`, `tracestrackApiKey`, `thunderforestApiKey` → `config.js` (see [step 3](#3-configure-api-keys) above)
+- Mapbox token → `config.php`, as `$mapboxToken` (see [step 4](#4-configure-staticmapphp-optional) above), only needed if you use `staticmap.php`
+
+**Running out of quota?** If routes stop building or tiles stop loading, you may have hit a provider's rate limit or daily quota. `maprouter.php` shows a popup naming the specific provider (and whether it's a rate limit or quota problem) when this happens, so check for that first before assuming something else is broken.
 
 ---
 
@@ -283,6 +303,7 @@ https://yourdomain.com/maprouter.php?route=[{"point":"Amsterdam"},{"point":"Utre
 | 2026-07-02 | `mapbuilder.php`: added reorder (▲/▼) and move (📍 / "move into route") controls so stops and location markers can be rearranged before generating the URL |
 | 2026-07-02 | README: clarified that `maprouter-builder.py` still works correctly, but `mapbuilder.php` is recommended for ease of use |
 | 2026-07-02 | Changed licence from MIT to PolyForm Noncommercial 1.0.0 — free for noncommercial use, commercial use requires separate permission |
+| 2026-07-02 | README: added an "API keys" chapter listing every required key, what it's for, where to sign up, and free-tier limits; also fixed a broken paragraph in the `staticmap.php` setup step |
 
 ---
 


### PR DESCRIPTION
## Summary
- Clarified in the setup section that `maprouter-builder.py` still works correctly, but `mapbuilder.php` is recommended for ease of use (no-install browser GUI with live URL preview and the reorder/move controls).
- Changed the project licence from MIT to **PolyForm Noncommercial License 1.0.0** — free to use, modify, and share for any noncommercial purpose; commercial use requires separate permission from the licensor. `LICENSE` and the README's licence section are both updated.
- Added a new **"API keys"** chapter documenting every key the project can use (OpenRouteService, Tracestrack, Thunderforest, Mapbox): what it's for, where to sign up, current free-tier limits, and which config file it goes in (`config.js` vs `config.php`).
- Fixed a paragraph in the `staticmap.php` setup step that had lost its inline code spans and some content in an earlier edit.
- Changelog entries added for all of the above.

## Test plan
- [x] Read through the rendered Markdown structure and verified heading anchors used in cross-references (`#api-keys`, `#3-configure-api-keys`, `#4-configure-staticmapphp-optional`) match GitHub's auto-generated slugs.
- [x] Verified the restored `config.php` / `$mapboxToken` snippet in step 4 matches the actual variable name read by `staticmap.php`.
- Documentation-only change — no code paths affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KsSSg4xLiNubcwsosj8nQe)_